### PR TITLE
improvements to vote restart when admins are on

### DIFF
--- a/code/controllers/subsystem/voting.dm
+++ b/code/controllers/subsystem/voting.dm
@@ -118,10 +118,14 @@ var/datum/subsystem/vote/SSvote
 	if(restart)
 		var/active_admins = 0
 		for(var/client/C in admins)
-			if(!C.is_afk())
-				active_admins++
-		if(active_admins <= 0)
+			if(!C.is_afk() && check_rights_for(C, R_SERVER))
+				active_admins = 1
+				break
+		if(!active_admins)
 			world.Reboot("Restart vote successful.", "end_error", "restart vote")
+		else
+			world << "<span style='boldannounce'>Notice:Restart vote will not restart the server automatically because there are active admins on.</span>"
+			message_admins("A restart vote has passed, but there are active admins on with +server, so it has been canceled. If you wish, you may restart the server.")
 
 	return .
 


### PR DESCRIPTION
It will only count admins who can actually restart the server.

It will stop searching for admins once it finds one.

It will let the users and admins know that the restart vote will not automatically restart the server because of the active admins.